### PR TITLE
Deploy TFC-Badge as example using ArgoCD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
 # deployments
 This repository contains deployment manifests for mindtastic's services
+
+# Usage
+
+## Creating and deploying a new application
+
+In order to deploy a new application to Kuberentes you will need to do the following two things:
+1. Create an `Application` manifest in `./applications`;
+    You can use the template below to create an application manifest for your application. 
+    Give it an appropriate name and store it in `./application`.
+2. create matching Kubernetes manifests for your application in a top level directory.
+    Create a directory for your application manifests and save them.
+    Make sure that your application manifest matches the directory name in the `.spec.source.path` attribute.
+
+Once merged to the main branch, your new application should show up in ArgoCD shortly after.
+
+Just press "Sync" to consolidate the manifests and cluster state and deploy your application.
+
+### Application Manifest Template
+
+Use the following template to create a new Application Manifest:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: guestbook   # The name of your application
+  namespace: argocd # Do not change this
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mindtastic/deployments
+    targetRevision: HEAD
+    path: guestbook # This points to the path where your application's manifests are stored
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: guestbook # Namespace for your application
+```
+
+# Bootstraping
+
+This repository is (mostly) fully automated. It follows ArgoCD's "[App-of-Apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/)" pattern, albeit with small differences.
+
+`./umbrella.yaml` deploys an ArgoCD application which creates all other applications stored in `./applications`.
+
+When bootstrapping a new Cluster, `umbrella.yaml` needs to be applied manually. After that it automatically adds all new applications added without any need to sync `umbrella` again.

--- a/applications/tfc-badge.yaml
+++ b/applications/tfc-badge.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tfc-badge
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mindtastic/deployments
+    targetRevision: HEAD
+    path: tfc-badge
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tfc-badge

--- a/applications/tfc-badge.yaml
+++ b/applications/tfc-badge.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/mindtastic/deployments
-    targetRevision: feat/argo-example
+    targetRevision: HEAD
     path: tfc-badge
   destination:
     server: https://kubernetes.default.svc

--- a/applications/tfc-badge.yaml
+++ b/applications/tfc-badge.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/mindtastic/deployments
-    targetRevision: HEAD
+    targetRevision: feat/argo-example
     path: tfc-badge
   destination:
     server: https://kubernetes.default.svc

--- a/tfc-badge/deployment.yaml
+++ b/tfc-badge/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tfc-badge
+  namespace: tfc-badge
+  labels:
+    name: tfc-badge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tfc-badge
+  template:
+    metadata:
+      labels:
+        app: tfc-badge
+    spec:
+      containers:
+      - name: tfc-badge
+        # Based on https://github.com/ldb/tfc-badge
+        image: cosmonawt/tfc-badge:latest
+        ports:
+          - containerPort: 3030
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/tfc-badge/ingress.yaml
+++ b/tfc-badge/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: tfc-badge
 spec:
   rules:
-  - host: tfc-badge.sam-app.ro
+  - host: tfc-badge.net.live.mindtastic.lol
     http:
       paths:
         - backend:

--- a/tfc-badge/ingress.yaml
+++ b/tfc-badge/ingress.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: ingress-tfc-badge
+  namespace: tfc-badge
+spec:
+  rules:
+  - host: tfc-badge.sam-app.ro
+    http:
+      paths:
+        - backend:
+            serviceName: tfc-badge
+            servicePort: 3030

--- a/tfc-badge/namespace.yaml
+++ b/tfc-badge/namespace.yaml
@@ -1,0 +1,6 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: tfc-badge
+  labels:
+    name: tfc-badge

--- a/tfc-badge/service.yaml
+++ b/tfc-badge/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tfc-badge
+  namespace: tfc-badge
+spec:
+  ports:
+  - name: http
+    protocol: TCP
+    port: 3030
+  selector:
+    app: tfc-badge

--- a/umbrella.yaml
+++ b/umbrella.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: applications
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mindtastic/deployments
+    targetRevision: HEAD
+    path: applications
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+      allowEmpty: false
+    syncOptions:
+    - CreateNamespace=true
+    - PrunePropagationPolicy=foreground
+    - PruneLast=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m


### PR DESCRIPTION
This change showcases an example use case of ArgoCD which is deployed in mindtastic/infra. It also creates basic application manifests that are necessary to automate the whole Deployment pipeline.

fixes #1 