### PR TITLE
Enable CORS for all origins on dev

### DIFF
--- a/bouncer/values-dev.yaml
+++ b/bouncer/values-dev.yaml
@@ -12,9 +12,8 @@ podCommand:
 ingress:
   enabled: true
   className: "traefik"
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: allowCORS@file
   hosts:
     - host: auth.api.dev.mindtastic.lol
       paths:

--- a/bouncer/values-live.yaml
+++ b/bouncer/values-live.yaml
@@ -11,8 +11,9 @@ podCommand:
 ingress:
   enabled: true
   className: "traefik"
-  annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: allowCORS@file
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: auth.api.live.mindtastic.lol
       paths:

--- a/bouncer/values-live.yaml
+++ b/bouncer/values-live.yaml
@@ -11,9 +11,8 @@ podCommand:
 ingress:
   enabled: true
   className: "traefik"
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: allowCORS@file
   hosts:
     - host: auth.api.live.mindtastic.lol
       paths:

--- a/kagami/values-dev.yaml
+++ b/kagami/values-dev.yaml
@@ -2,7 +2,8 @@ ingress:
   enabled: true
   className: "traefik"
   annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: auth@file
+    traefik.ingress.kubernetes.io/router.middlewares: auth@file,allowCORS@file
+
   hosts:
     - host: "echo.api.dev.mindtastic.lol"
       paths:

--- a/kratos/values-dev.yaml
+++ b/kratos/values-dev.yaml
@@ -4,6 +4,7 @@ ingress:
     className: ""
     annotations:
       kubernetes.io/ingress.class: traefik
+      traefik.ingress.kubernetes.io/router.middlewares: allowCORS@file
       #kubernetes.io/tls-acme: "true"
     hosts:
       - host: auth.api.dev.mindtastic.lol

--- a/traefik/values-common.yaml
+++ b/traefik/values-common.yaml
@@ -4,6 +4,11 @@ config: |-
     [http.middlewares.auth.forwardAuth]
       address = "http://oathkeeper-api.oathkeeper.svc.cluster.local:4456/decisions"
       authResponseHeaders = "X-User-Id"
+    [http.middlewares.allowCORS.headers]
+      accessControlAllowMethods = ["GET", "OPTIONS", "PUT"]
+      accessControlAllowOriginList = ["*"]
+      accessControlMaxAge = 100
+      addVaryHeader = true
 
 # Default values for Traefik
 image:


### PR DESCRIPTION
Our DEMO app for the presentation will be stopped by CORS when on development server, due to calling different API endpoints.

Therefore we are enabling wildcard cors on all demo relevant ressources. Later, we might need to add allow headers for cross endpoint ressource usage